### PR TITLE
fix: serve dependencies at /bower_components/

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -32,12 +32,12 @@
               {
                 "glob": "**/*",
                 "input": "src/app/angularjs/bower_components",
-                "output": "/public/libs/"
+                "output": "/bower_components/"
               },
               {
                 "glob": "**/*",
                 "input": "src/app/angularjs",
-                "ignore": ["src/app/angularjs/bower_components/*"],
+                "ignore": ["src/app/angularjs/bower_components/*, src/app/angularjs/node_modules/*"],
                 "output": "/"
               }
             ],

--- a/src/index.html
+++ b/src/index.html
@@ -9,26 +9,26 @@ window.console = window.console || {};
 window.console.log = window.console.log || function(){};
 </script>
 
-<script src="/public/libs/jquery/dist/jquery.js"></script>
-<script src="/public/libs/bootstrap/dist/js/bootstrap.js"></script>
-<script src="/public/libs/chart.js/dist/Chart.js"></script>
-<script src="/public/libs/underscore/underscore.js"></script>
-<script src="/public/libs/angular/angular.js"></script>
-<script src="/public/libs/ngstorage/ngStorage.js"></script>
-<script src="/public/libs/angular-cookies/angular-cookies.js"></script>
-<script src="/public/libs/angular-bootstrap/ui-bootstrap-tpls.js"></script>
-<script src="/public/libs/datatables.net/js/jquery.dataTables.js"></script>
-<script src="/public/libs/datatables.net-bs/js/dataTables.bootstrap.js"></script>
-<script src="/public/libs/datatables.net-select/js/dataTables.select.js"></script>
-<script src="/public/libs/jstree/dist/jstree.js"></script>
-<script src="/public/libs/jquery-file-download/src/Scripts/jquery.fileDownload.js"></script>
-<script src="/public/libs/ng-file-upload/ng-file-upload.js"></script>
+<script src="/bower_components/jquery/dist/jquery.js"></script>
+<script src="/bower_components/bootstrap/dist/js/bootstrap.js"></script>
+<script src="/bower_components/chart.js/dist/Chart.js"></script>
+<script src="/bower_components/underscore/underscore.js"></script>
+<script src="/bower_components/angular/angular.js"></script>
+<script src="/bower_components/ngstorage/ngStorage.js"></script>
+<script src="/bower_components/angular-cookies/angular-cookies.js"></script>
+<script src="/bower_components/angular-bootstrap/ui-bootstrap-tpls.js"></script>
+<script src="/bower_components/datatables.net/js/jquery.dataTables.js"></script>
+<script src="/bower_components/datatables.net-bs/js/dataTables.bootstrap.js"></script>
+<script src="/bower_components/datatables.net-select/js/dataTables.select.js"></script>
+<script src="/bower_components/jstree/dist/jstree.js"></script>
+<script src="/bower_components/jquery-file-download/src/Scripts/jquery.fileDownload.js"></script>
+<script src="/bower_components/ng-file-upload/ng-file-upload.js"></script>
 <script src="/js/angular-resizable.js"></script>
 
-<script src="/public/libs/d3/d3.js"></script>
-<script src="/public/libs/nvd3/build/nv.d3.js"></script>
-<script src="/public/libs/angular-nvd3/dist/angular-nvd3.js"></script>
-<script src="/public/libs/exense-visualization/dist/viz.js"></script>
+<script src="/bower_components/d3/d3.js"></script>
+<script src="/bower_components/nvd3/build/nv.d3.js"></script>
+<script src="/bower_components/angular-nvd3/dist/angular-nvd3.js"></script>
+<script src="/bower_components/exense-visualization/dist/viz.js"></script>
 
 <link rel="icon" type="image/png" href="favicon.png">
 
@@ -67,15 +67,15 @@ window.console.log = window.console.log || function(){};
 <script src="/js/viz-presets-commons.js"></script>
 <script src="/js/viz-presets-ext.js"></script>
 
-<link rel="stylesheet" href="/public/libs/bootstrap/dist/css/bootstrap.css" />
-<link rel="stylesheet" href="/public/libs/datatables.net-bs/css/dataTables.bootstrap.css" />
-<link rel="stylesheet" href="/public/libs/datatables.net-select-dt/css/select.dataTables.css" />
-<link rel="stylesheet" href="/public/libs/jstree/dist/themes/default/style.css" />
-<link rel="stylesheet" href="/public/libs/tachyons/css/tachyons.css" />
-<link rel="stylesheet" href="/public/libs/angular-resizable/angular-resizable.min.css" />
+<link rel="stylesheet" href="/bower_components/bootstrap/dist/css/bootstrap.css" />
+<link rel="stylesheet" href="/bower_components/datatables.net-bs/css/dataTables.bootstrap.css" />
+<link rel="stylesheet" href="/bower_components/datatables.net-select-dt/css/select.dataTables.css" />
+<link rel="stylesheet" href="/bower_components/jstree/dist/themes/default/style.css" />
+<link rel="stylesheet" href="/bower_components/tachyons/css/tachyons.css" />
+<link rel="stylesheet" href="/bower_components/angular-resizable/angular-resizable.min.css" />
 
-<link rel="stylesheet" href="/public/libs/nvd3/build/nv.d3.css">
-<link rel="stylesheet" href="/public/libs/exense-visualization/dist/viz.css">
+<link rel="stylesheet" href="/bower_components/nvd3/build/nv.d3.css">
+<link rel="stylesheet" href="/bower_components/exense-visualization/dist/viz.css">
 
 <link rel="stylesheet" type="text/css" href="/css/step.css">
 <link rel="stylesheet" type="text/css" href="/css/step-variables.css">


### PR DESCRIPTION
currently the dependency `exense-visualization` should depend on the dependencies being served under `/bower_components/` but I am not sure as I am unable to test the functionality 