### PR TITLE
Handle errors for plugins loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ testem.log
 # System Files
 .DS_Store
 Thumbs.db
+
+# Plugins
+/src/plugins

--- a/angular.json
+++ b/angular.json
@@ -31,6 +31,11 @@
               "src/assets",
               {
                 "glob": "**/*",
+                "input": "src/plugins",
+                "output": "/"
+              },
+              {
+                "glob": "**/*",
                 "input": "src/app/angularjs/bower_components",
                 "output": "/bower_components/"
               },
@@ -41,9 +46,7 @@
                 "output": "/"
               }
             ],
-            "styles": [
-              "src/styles.scss"
-            ],
+            "styles": ["src/styles.scss"],
             "scripts": []
           },
           "configurations": {
@@ -106,13 +109,8 @@
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
             "inlineStyleLanguage": "scss",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.scss"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.scss"],
             "scripts": []
           }
         }

--- a/src/app/plugins-initializer.ts
+++ b/src/app/plugins-initializer.ts
@@ -8,17 +8,19 @@ export interface PluginDefinition {
 }
 
 const loadScript = (fileName: string): Promise<unknown> =>
-  new Promise<unknown>((resolve) => {
-    const callback = () => {
+  new Promise<unknown>((resolve, reject) => {
+    const callbackSuccess = () => {
       console.log(`Loaded plugin script ${fileName}`);
       resolve(true);
     };
+    const callbackError = (err: any) => reject(err);
     const script = document.createElement('script');
     script.setAttribute('type', 'text/javascript');
     script.setAttribute('src', fileName);
     //@ts-ignore
-    script.onreadystatechange = callback;
-    script.onload = callback;
+    script.onreadystatechange = callbackSuccess;
+    script.onload = callbackSuccess;
+    script.onerror = callbackError;
     document.querySelector('head')!.appendChild(script);
   });
 
@@ -27,8 +29,7 @@ const loadSinglePlugin = async (pluginDefinition: PluginDefinition): Promise<str
     const scriptsLoad = pluginDefinition.scripts.map((script) => loadScript(script));
     await Promise.all(scriptsLoad);
   } catch (e) {
-    console.log(`Module(s) ${pluginDefinition.angularModules.join(', ')} load fail`);
-    console.log(e);
+    console.log(`Module(s) ${pluginDefinition.angularModules.join(', ')} load fail`, e);
     return [];
   }
   return pluginDefinition.angularModules;
@@ -40,8 +41,7 @@ const fetchDefinitions = async (): Promise<PluginDefinition[]> => {
     const pluginsResponse = await fetch('/rest/app/plugins');
     result = (await pluginsResponse.json()) as PluginDefinition[];
   } catch (e) {
-    console.log('Fetch plugin definitions failed');
-    console.log(e);
+    console.log('Fetch plugin definitions failed', e);
   }
   return result;
 };

--- a/src/app/plugins-initializer.ts
+++ b/src/app/plugins-initializer.ts
@@ -29,7 +29,7 @@ const loadSinglePlugin = async (pluginDefinition: PluginDefinition): Promise<str
     const scriptsLoad = pluginDefinition.scripts.map((script) => loadScript(script));
     await Promise.all(scriptsLoad);
   } catch (e) {
-    console.log(`Module(s) ${pluginDefinition.angularModules.join(', ')} load fail`, e);
+    console.error(`Module(s) ${pluginDefinition.angularModules.join(', ')} load fail`, e);
     return [];
   }
   return pluginDefinition.angularModules;

--- a/src/index.html
+++ b/src/index.html
@@ -32,7 +32,6 @@
 
     <link rel="icon" type="image/png" href="favicon.png" />
 
-    <script src="/js/bootstrap.js"></script>
     <script src="/js/common.js"></script>
     <script src="/js/app.js"></script>
     <script src="/js/views.js"></script>


### PR DESCRIPTION
1. I've add the folder src/plugins and put it to gitignore. It should affect the build, but it will help to test plugins locally. So I decided to include it in this commit also.
2. js/bootstrap.js was removed in previous PR, but I forgot to delete it's script inclusion. Now the inclusion has been deleted also.
3. onerror callback was added to plugin's script load to avoid the application start failure if one of the plugins is not available.

The plugins load became more stable. For example if `monitoringdashboard` wont be available, user won't see the tab monitoring, but the whole app will continue to work. But there are some cases, when error handling on scripts load won't help.
Some plugins are depend on each other. For example `monitoringdashboard` depends on `notifications`, and we can not analyze plugins dependencies during the load. It means that if `notifications` scripts won't be available, `monitoringdashboard` won't be able to start properly and it will brake the application.