### PR TITLE
SED-1146 fixed uplot errors

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -43,8 +43,8 @@
                 "output": "/"
               }
             ],
-            "styles": ["projects/step-app/src/styles.scss"],
-            "scripts": [],
+            "styles": ["projects/step-app/src/styles.scss", "node_modules/uplot/dist/uPlot.min.css"],
+            "scripts": ["node_modules/uplot/dist/uPlot.iife.min.js"],
             "extraWebpackConfig": "projects/step-app/webpack.config.js",
             "commonChunk": false
           },

--- a/projects/step-frontend/src/lib/modules/timeseries/execution-page/execution-page.component.ts
+++ b/projects/step-frontend/src/lib/modules/timeseries/execution-page/execution-page.component.ts
@@ -391,7 +391,7 @@ export class ExecutionPageComponent implements OnInit, OnDestroy {
     let dimensionKey = 'name';
     this.timeSeriesService.fetchBucketsNew({ ...request, groupDimensions: [dimensionKey] }).subscribe((response) => {
       let timeLabels = this.createTimeLabels(response.start, response.end, response.interval);
-      let totalData: number[] = Array(response.matrix[0].length); // TODO handle empty response
+      let totalData: number[] = !!response.matrix[0] ? Array(response.matrix[0].length) : []; // TODO handle empty response
       let avgSeries: TSChartSeries[] = [];
       let countSeries = [];
       let series = response.matrixKeys.map((key, i) => {


### PR DESCRIPTION
fixes:
- `uPlot not defined` error
- `length of undefined` error when there is not data

After a lots of back and forths, tries and errors, here is the smallest changeset that works. In the end @neogucky was right, it simply had to do with missing dependencies, not in a `package.json`, but in the `angular.json` in the Step-Frontend project.

All globally declared `uPlot` variables have been used with `declare` keyword, which is solely for the ts-compiler and is irgnored by the js compiler, therefore it can not do harm. It is ugly anyways, but as it is going to be refactored, I leave it as it is for now.

And now we also know how to simulate the way the (production) server serves the app ;) https://exense.atlassian.net/wiki/spaces/DEVELOPMEN/pages/527728645/How+to+serve+from+local+HTTP-Server