### PR TITLE
SED-1309 The search by Keyword type on the Keyword table doesn't work properly

### DIFF
--- a/projects/step-frontend/src/lib/modules/function/components/function-list/function-list.component.html
+++ b/projects/step-frontend/src/lib/modules/function/components/function-list/function-list.component.html
@@ -55,9 +55,11 @@
     </td>
   </ng-container>
   <step-custom-columns screen="functionTable"> </step-custom-columns>
-  <ng-container matColumnDef="type" stepSearchCol>
+  <ng-container matColumnDef="type" stepSearchCol #searchState="SearchCol">
+    <step-function-type-filter *stepSearchCellDef (selectedItemsChange)="searchState.search($event, true)">
+    </step-function-type-filter>
     <th mat-header-cell *matHeaderCellDef mat-sort-header>Type</th>
-    <td mat-cell *matCellDef="let element">{{ functionTypeLabel(element.type) }}</td>
+    <td mat-cell *matCellDef="let element">{{ element.type | functionTypeLabel }}</td>
   </ng-container>
   <step-custom-columns screen="functionTableExtensions" [isSearchDisabled]="true"> </step-custom-columns>
   <ng-container matColumnDef="actions">

--- a/projects/step-frontend/src/lib/modules/function/components/function-list/function-list.component.ts
+++ b/projects/step-frontend/src/lib/modules/function/components/function-list/function-list.component.ts
@@ -95,12 +95,8 @@ export class FunctionListComponent {
     this._functionDialogs.openLookUpFunctionDialog(id, name).subscribe(noop);
   }
 
-  configureFunction(id: string) {
+  configureFunction(id: string): void {
     this._functionDialogs.configureFunction(id).subscribe((_) => this.dataSource.reload());
-  }
-
-  functionTypeLabel(type: string) {
-    return this._functionTypeRegistry.getLabel(type);
   }
 }
 

--- a/projects/step-frontend/src/lib/modules/function/components/function-type-filter/function-type-filter.component.html
+++ b/projects/step-frontend/src/lib/modules/function/components/function-type-filter/function-type-filter.component.html
@@ -1,0 +1,7 @@
+<mat-form-field>
+  <mat-select multiple (selectionChange)="handleChange($event)">
+    <mat-option *ngFor="let item of functionTypes" [value]="item.key">
+      {{ item.value }}
+    </mat-option>
+  </mat-select>
+</mat-form-field>

--- a/projects/step-frontend/src/lib/modules/function/components/function-type-filter/function-type-filter.component.ts
+++ b/projects/step-frontend/src/lib/modules/function/components/function-type-filter/function-type-filter.component.ts
@@ -1,0 +1,23 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { AJS_FUNCTION_TYPE_REGISTRY, ArrayFilterComponent } from '@exense/step-core';
+
+@Component({
+  selector: 'step-function-type-filter',
+  templateUrl: './function-type-filter.component.html',
+  styleUrls: ['./function-type-filter.component.scss'],
+})
+export class FunctionTypeFilterComponent extends ArrayFilterComponent implements OnInit {
+  constructor(@Inject(AJS_FUNCTION_TYPE_REGISTRY) private _functionTypeRegistry: any) {
+    super();
+  }
+
+  functionTypes: { key: string; value: string }[] = [];
+
+  ngOnInit(): void {
+    const keys = this._functionTypeRegistry.getTypes() as string[];
+    this.functionTypes = keys.map((key) => {
+      const value = this._functionTypeRegistry.getLabel(key);
+      return { key, value };
+    });
+  }
+}

--- a/projects/step-frontend/src/lib/modules/function/function.module.ts
+++ b/projects/step-frontend/src/lib/modules/function/function.module.ts
@@ -6,6 +6,8 @@ import { FunctionPackageLinkComponent } from './components/function-package-link
 import { FunctionPackageListComponent } from './components/function-package-list/function-package-list.component';
 import { FunctionIconComponent } from './components/function-icon/function-icon.component';
 import { FunctionLinkComponent } from './components/function-link/function-link.component';
+import { FunctionTypeLabelPipe } from './pipes/function-type-label.pipe';
+import { FunctionTypeFilterComponent } from './components/function-type-filter/function-type-filter.component';
 
 @NgModule({
   declarations: [
@@ -14,6 +16,8 @@ import { FunctionLinkComponent } from './components/function-link/function-link.
     FunctionPackageListComponent,
     FunctionIconComponent,
     FunctionLinkComponent,
+    FunctionTypeLabelPipe,
+    FunctionTypeFilterComponent,
   ],
   imports: [StepCommonModule, StepCoreModule, StepBasicsModule],
   exports: [FunctionListComponent],

--- a/projects/step-frontend/src/lib/modules/function/pipes/function-type-label.pipe.ts
+++ b/projects/step-frontend/src/lib/modules/function/pipes/function-type-label.pipe.ts
@@ -1,0 +1,13 @@
+import { Inject, Pipe, PipeTransform } from '@angular/core';
+import { AJS_FUNCTION_TYPE_REGISTRY } from '@exense/step-core';
+
+@Pipe({
+  name: 'functionTypeLabel',
+})
+export class FunctionTypeLabelPipe implements PipeTransform {
+  constructor(@Inject(AJS_FUNCTION_TYPE_REGISTRY) private _functionTypeRegistry: any) {}
+
+  transform(type: string): string {
+    return this._functionTypeRegistry.getLabel(type);
+  }
+}


### PR DESCRIPTION
To pass the right keyword type in request properly, I've change the search column from the free text to the dropdown filter, where all registered keyword types are displayed as dropdown's items.