### PR TITLE
SED-1434 enables input and make it changeable

### DIFF
--- a/projects/step-frontend/src/lib/angularjs/partials/resources/editResourceDialog.html
+++ b/projects/step-frontend/src/lib/angularjs/partials/resources/editResourceDialog.html
@@ -31,7 +31,7 @@
 		</div>
 		<div class="form-group" ng-if="mode==='edit'">
 			<label>Name</label>
-			<input class="form-control"	ng-model="resource.attributes.name" autofocus disabled>
+			<input class="form-control"	ng-model="resource.resourceName" autofocus>
 		</div>
 		<div class="form-group" ng-if="mode==='edit'">
 			<label>Type</label>


### PR DESCRIPTION
From the description:

- [x]  **Name field not not be disabled**: it is enabled now and the payload of the post request has the new name in the correct field
- [x] **Type should be disabled**
- [x] **Fileselect should be readonly="uploadOnly"**: I don't know what is meant by that exactly
- [x] **Important: name field and file should not be linked**: Done as far we can get in the FE. Before both fields pointed to the same variable as ng-model, now they differ, so while editing they are not linked anymore. **However, after editing, the filename and the resource name are the same again**. That is because the BE does not provide us with the filename.
Example response of `POST [server]/rest/table/resources`:
```
    {
      "customFields": null,
      "attributes": {
        "name": "touched.txt"
      },
      "currentRevisionId": "633d8d4011fdd01cff5516e2",
      "resourceType": "pdfTestScenarioFile",
      "resourceName": "touched.txt",
      "directory": false,
      "ephemeral": false,
      "id": "633d8d4011fdd01cff5516e1"
    }
```
where `attributes.name` and `resourceName` always have equal content. There is no filename field.

While editing:
![image](https://user-images.githubusercontent.com/3681858/194086751-9b53ccfa-480c-4114-8ec9-96ee6ace85ce.png)
After editing:
![image](https://user-images.githubusercontent.com/3681858/194086871-ebc304ea-bfcf-473c-bdfe-684d39488b5d.png)

When the file is downloaded, its filename is still `touched.txt`