### PR TITLE
SED-2575 Missing driver class field for Foreach and Dataset controls

### DIFF
--- a/projects/step-frontend/src/lib/modules/artefacts/component/data-source-configuration/data-source-configuration.component.html
+++ b/projects/step-frontend/src/lib/modules/artefacts/component/data-source-configuration/data-source-configuration.component.html
@@ -58,6 +58,13 @@
         >
         </step-dynamic-textfield>
         <step-dynamic-textfield
+          label="Driver class"
+          [(ngModel)]="context.artefact!.dataSource!.driverClass"
+          [disabled]="context.readonly"
+          name="driverClass"
+        >
+        </step-dynamic-textfield>
+        <step-dynamic-textfield
           label="Query"
           [(ngModel)]="context.artefact!.dataSource!.query"
           [disabled]="context.readonly"


### PR DESCRIPTION
SED-2575 Missing driver class field for Foreach and Dataset controls (#627)

(cherry picked from commit f27b4a80c36cf1fe28dbb95b5575b5f4c92c2b81)