### PR TITLE
SED-3326 fixed browser back broken for executions

### DIFF
--- a/projects/step-frontend/src/lib/modules/execution/components/execution-opener/execution-opener.component.ts
+++ b/projects/step-frontend/src/lib/modules/execution/components/execution-opener/execution-opener.component.ts
@@ -12,6 +12,6 @@ export class ExecutionOpenerComponent implements OnInit {
 
   ngOnInit(): void {
     const id = this._activatedRoute.snapshot.params['id'];
-    this._router.navigate(['.', id], { relativeTo: this._activatedRoute.parent });
+    this._router.navigate(['.', id, 'steps'], { relativeTo: this._activatedRoute.parent, replaceUrl: true });
   }
 }


### PR DESCRIPTION
Going back did not work because execution button leads to `/executions/open/${id}` which replaces the history.
 