### PR TITLE
SED-3326 Dialog close behaivor on history back

### DIFF
--- a/projects/step-core/src/lib/modules/basics/components/dialog-route/dialog-route.component.ts
+++ b/projects/step-core/src/lib/modules/basics/components/dialog-route/dialog-route.component.ts
@@ -1,7 +1,7 @@
 import { Component, DestroyRef, inject, OnDestroy, OnInit, Type, ViewContainerRef } from '@angular/core';
 import { ActivatedRoute, Data, Router } from '@angular/router';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
-import { map, Subject, switchMap, takeUntil, timer } from 'rxjs';
+import { asyncScheduler, map, observeOn, Subject, switchMap, takeUntil, timer } from 'rxjs';
 import { DialogParentService } from '../../injectables/dialog-parent.service';
 import { DialogRouteResult } from '../../types/dialog-route-result';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -57,6 +57,7 @@ export class DialogRouteComponent implements OnInit, OnDestroy {
           result.canNavigateBack = result.canNavigateBack ?? true;
           return result;
         }),
+        observeOn(asyncScheduler),
         takeUntil(this.dialogCloseTerminator$),
       )
       .subscribe((result) => {


### PR DESCRIPTION
The main issue occurred, because `exitRoute` method was invoked before route's navigation events were performed in case of history back actions.
It caused the situation, that navigation in `exitRoute` overrode browser history with new items.
Applying `asyncScheduler` fixed it.
In case of back navigation - route event's performs first. It destroys the component and unsubscribe from dialog close events. `exitRoute` no longer invoked in this case and doesn't spoil the history, with unnecessary navigation.