### PR TITLE
SED-4100 wrapping ap execution into test set has no default value for the number of threads

### DIFF
--- a/projects/step-frontend/src/lib/modules/automation-packages/components/automation-package-execution-dialog/automation-package-execution-dialog.component.ts
+++ b/projects/step-frontend/src/lib/modules/automation-packages/components/automation-package-execution-dialog/automation-package-execution-dialog.component.ts
@@ -39,7 +39,7 @@ export class AutomationPackageExecutionDialogComponent implements OnInit {
 
   protected readonly executionConfigForm = this._fb.group({
     wrapIntoTestSet: this._fb.control(false),
-    numberOfThreads: this._fb.control(1, [Validators.min(1)]),
+    numberOfThreads: this._fb.control(1, [Validators.min(0)]),
     includedNames: this._fb.control<string[]>([]),
     excludedNames: this._fb.control<string[]>([]),
     includedCategories: this._fb.control<string[]>([]),


### PR DESCRIPTION
… the number of threads